### PR TITLE
fix: added missing SQS config from lesson 07

### DIFF
--- a/lessons/08-worker-lambda/template.yml
+++ b/lessons/08-worker-lambda/template.yml
@@ -72,6 +72,16 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: app.purchase
+      Environment:
+        Variables:
+          SQS_QUEUE_URL: !Ref "ticketPurchasedQueue"
+      Policies:
+        - Statement:
+            - Sid: PurchaseAllowSQSSendMessage
+              Effect: Allow
+              Action:
+                - sqs:SendMessage
+              Resource: !GetAtt "ticketPurchasedQueue.Arn"
       Events:
         Endpoint:
           Type: Api
@@ -86,6 +96,11 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - app.ts
+
+  ticketPurchasedQueue:
+    Type: "AWS::SQS::Queue"
+    Properties:
+      QueueName: "timelessmusic-purchase"
 
   worker:
     Type: AWS::Serverless::Function
@@ -112,3 +127,8 @@ Outputs:
     Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
     Export:
       Name: timelessmusic:api-endpoint
+  queueUrl:
+    Description: The URL of the ticket purchase queue
+    Value: !Ref "ticketPurchasedQueue"
+    Export:
+      Name: timelessmusic:sqs-queue


### PR DESCRIPTION
Added the SQS config from [lessons/07-send-messages-to-sqs/template.yml](https://github.com/fourTheorem/serverless-ecommerce-workshop/blob/main/lessons/07-send-messages-to-sqs/template.yml) that was missing from lesson 08' template.yml